### PR TITLE
chore: Adjusted link styling in the brand header

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -74,7 +74,7 @@ export default function Container({
         <div className="container">
           <div className="row flex-nowrap justify-content-between align-items-center">
             <div className="col-6 pt-1">
-              <Link href="/">
+              <Link href="/" className='link-offset-2 link-underline link-underline-opacity-0'>
                 <h4>
                   IT
                   <strong>


### PR DESCRIPTION
- Added the following classes to the brand link in the header:
  - link-offset-2
  - link-underline
  - link-underline-opacity-0

These classes were added to achieve a specific styling effect for the brand link in the header.
